### PR TITLE
search: Add header to results message

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -95,8 +95,8 @@ module.exports = {
       searchResults[message.member.user.username] = results;
 
       var resultEntries = results.map((result, index) => `${index}) "${result.title}", by channel "${result.channelTitle}"`);
-      var resultMessage = resultEntries.join("\n");
-      message.channel.send(resultMessage);
+      var resultList = resultEntries.join("\n");
+      message.channel.send(`Search results:\n${resultList}`);
     });
   },
 


### PR DESCRIPTION
This commit adds the header "Search results:\n" to the message listing the search results. This patch has not been tested.